### PR TITLE
#24 Set Tickets Filter Panel Closed by Default

### DIFF
--- a/src/components/molecules/TicketFiltersBar.tsx
+++ b/src/components/molecules/TicketFiltersBar.tsx
@@ -48,7 +48,7 @@ export default function TicketFiltersBar({
   onSortDirectionChange,
   onReset,
 }: TicketFiltersBarProps) {
-  const [showFilters, setShowFilters] = useState(true);
+  const [showFilters, setShowFilters] = useState(false);
 
   const setFilter = <K extends keyof TicketListFilters>(
     key: K,


### PR DESCRIPTION
This pull request makes a minor update to the `TicketFiltersBar` component, changing the default visibility of the filters. Now, the filters are hidden by default when the component mounts, instead of being shown.

* Changed the initial state of `showFilters` from `true` to `false` in `TicketFiltersBar`, so filters are hidden by default.