### PR TITLE
5: login page

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -12,6 +12,11 @@ import {
   ListItemIcon,
   ListItemText,
   CssBaseline,
+  Avatar,
+  Chip,
+  IconButton,
+  Tooltip,
+  Stack,
 } from "@mui/material";
 import {
   Home,
@@ -22,14 +27,18 @@ import {
   Settings,
   DirectionsCar,
   Assignment,
+  Logout,
+  Explore,
 } from "@mui/icons-material";
 
 import { routes } from "../router/routes";
+import { useAuth } from "../contexts/AuthContext";
 
 const drawerWidth = 240;
 
 const iconMap: Record<string, ComponentType> = {
   Home: Home,
+  Map: Explore,
   Stations: Map,
   Trips: DirectionsBus,
   Vehicles: DirectionsCar,
@@ -39,12 +48,29 @@ const iconMap: Record<string, ComponentType> = {
   Settings: Settings,
 };
 
+const ROLE_COLORS: Record<string, "default" | "primary" | "secondary" | "error" | "info" | "success" | "warning"> = {
+  ADMIN: "error",
+  OPERATOR: "primary",
+  TECHNICIAN: "warning",
+  SUPPORT: "info",
+  USER: "default",
+};
+
 export default function Layout() {
   const location = useLocation();
   const navigate = useNavigate();
+  const { currentUser, logout } = useAuth();
 
   const currentRoute = routes.find((r) => r.path === location.pathname);
   const pageTitle = currentRoute?.name || "Urbanova";
+
+  const userInitials = currentUser
+    ? `${currentUser.firstName[0]}${currentUser.lastName[0]}`
+    : "?";
+
+  const visibleRoutes = routes.filter(
+    (r) => !r.allowedRoles || r.allowedRoles.includes(currentUser?.role ?? ""),
+  );
 
   const drawer = (
     <div>
@@ -54,7 +80,7 @@ export default function Layout() {
         </Typography>
       </Toolbar>
       <List>
-        {routes.map((route) => {
+        {visibleRoutes.map((route) => {
           const Icon = iconMap[route.name];
           return (
             <ListItem key={route.path} disablePadding>
@@ -90,6 +116,42 @@ export default function Layout() {
           <Typography variant="h6" noWrap component="div" sx={{ flexGrow: 1 }}>
             {pageTitle}
           </Typography>
+
+          {currentUser && (
+            <Stack direction="row" sx={{ alignItems: "center" }} spacing={1.5}>
+              <Chip
+                label={currentUser.role}
+                size="small"
+                color={ROLE_COLORS[currentUser.role] ?? "default"}
+                sx={{ fontWeight: 600, fontSize: "0.7rem" }}
+              />
+              <Stack direction="row" sx={{ alignItems: "center" }} spacing={1}>
+                <Avatar
+                  sx={{
+                    width: 32,
+                    height: 32,
+                    fontSize: "0.8rem",
+                    fontWeight: 700,
+                    bgcolor: "primary.dark",
+                  }}
+                >
+                  {userInitials}
+                </Avatar>
+                <Typography variant="body2" sx={{ color: "inherit", fontWeight: 500 }}>
+                  {currentUser.firstName} {currentUser.lastName}
+                </Typography>
+              </Stack>
+              <Tooltip title="Sign out">
+                <IconButton
+                  size="small"
+                  sx={{ color: "inherit" }}
+                  onClick={logout}
+                >
+                  <Logout fontSize="small" />
+                </IconButton>
+              </Tooltip>
+            </Stack>
+          )}
         </Toolbar>
       </AppBar>
       <Box

--- a/src/components/RequireAuth.tsx
+++ b/src/components/RequireAuth.tsx
@@ -1,0 +1,14 @@
+import { Navigate, useLocation } from "react-router-dom";
+import { useAuth } from "../contexts/AuthContext";
+import type { ReactNode } from "react";
+
+export default function RequireAuth({ children }: { children: ReactNode }) {
+  const { isAuthenticated } = useAuth();
+  const location = useLocation();
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+
+  return <>{children}</>;
+}

--- a/src/components/atoms/RoleBadge.tsx
+++ b/src/components/atoms/RoleBadge.tsx
@@ -1,0 +1,24 @@
+import { Chip } from "@mui/material";
+import type { UserRole } from "../../types";
+
+const colorMap: Record<
+  string,
+  "default" | "error" | "primary" | "warning" | "info" | "success"
+> = {
+  ADMIN: "error",
+  OPERATOR: "primary",
+  TECHNICIAN: "warning",
+  SUPPORT: "info",
+  USER: "default",
+};
+
+export default function RoleBadge({ role }: { role: UserRole }) {
+  return (
+    <Chip
+      size="small"
+      label={role}
+      color={colorMap[role] ?? "default"}
+      sx={{ fontWeight: 600, fontSize: "0.72rem" }}
+    />
+  );
+}

--- a/src/components/organisms/UsersTable.tsx
+++ b/src/components/organisms/UsersTable.tsx
@@ -1,0 +1,200 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TableSortLabel,
+  Paper,
+  IconButton,
+  Tooltip,
+  Chip,
+  Typography,
+  Box,
+} from "@mui/material";
+import {
+  Edit,
+  Delete,
+  ToggleOn,
+  ToggleOff,
+  Visibility,
+} from "@mui/icons-material";
+import type { User } from "../../types";
+import RoleBadge from "../atoms/RoleBadge";
+
+interface Column {
+  id: string;
+  label: string;
+  sortable?: boolean;
+  width?: number | string;
+}
+
+const COLUMNS: Column[] = [
+  { id: "id", label: "ID", sortable: true, width: 100 },
+  { id: "firstName", label: "Name", sortable: true },
+  { id: "email", label: "Email", sortable: true },
+  { id: "role", label: "Role", sortable: true, width: 120 },
+  { id: "isActive", label: "Status", width: 100 },
+  { id: "lastLoginAt", label: "Last Login", sortable: true, width: 160 },
+  { id: "actions", label: "", width: 120 },
+];
+
+interface UsersTableProps {
+  users: User[];
+  sortBy: string;
+  sortOrder: "asc" | "desc";
+  onSort: (field: string) => void;
+  onView: (user: User) => void;
+  onEdit: (user: User) => void;
+  onToggleActive: (user: User) => void;
+  onDelete: (user: User) => void;
+  currentUserId?: string;
+}
+
+export default function UsersTable({
+  users,
+  sortBy,
+  sortOrder,
+  onSort,
+  onView,
+  onEdit,
+  onToggleActive,
+  onDelete,
+  currentUserId,
+}: UsersTableProps) {
+  return (
+    <TableContainer component={Paper} variant="outlined" sx={{ borderRadius: 2 }}>
+      <Table size="small">
+        <TableHead>
+          <TableRow sx={{ bgcolor: "grey.50" }}>
+            {COLUMNS.map((col) => (
+              <TableCell
+                key={col.id}
+                width={col.width}
+                sx={{ fontWeight: 700, fontSize: "0.8rem" }}
+              >
+                {col.sortable ? (
+                  <TableSortLabel
+                    active={sortBy === col.id}
+                    direction={sortBy === col.id ? sortOrder : "asc"}
+                    onClick={() => onSort(col.id)}
+                  >
+                    {col.label}
+                  </TableSortLabel>
+                ) : (
+                  col.label
+                )}
+              </TableCell>
+            ))}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {users.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={COLUMNS.length} sx={{ textAlign: "center", py: 6 }}>
+                <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                  No users found
+                </Typography>
+              </TableCell>
+            </TableRow>
+          ) : (
+            users.map((user) => {
+              const isSelf = user.id === currentUserId;
+              return (
+                <TableRow
+                  key={user.id}
+                  hover
+                  sx={{ opacity: user.isActive ? 1 : 0.6 }}
+                >
+                  <TableCell>
+                    <Typography variant="caption" sx={{ fontFamily: "monospace", fontWeight: 600 }}>
+                      {user.id}
+                    </Typography>
+                  </TableCell>
+                  <TableCell>
+                    <Box>
+                      <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                        {user.firstName} {user.lastName}
+                        {isSelf && (
+                          <Chip
+                            label="you"
+                            size="small"
+                            sx={{ ml: 1, height: 16, fontSize: "0.65rem" }}
+                          />
+                        )}
+                      </Typography>
+                    </Box>
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                      {user.email}
+                    </Typography>
+                  </TableCell>
+                  <TableCell>
+                    <RoleBadge role={user.role} />
+                  </TableCell>
+                  <TableCell>
+                    <Chip
+                      size="small"
+                      label={user.isActive ? "Active" : "Inactive"}
+                      color={user.isActive ? "success" : "default"}
+                      sx={{ fontWeight: 600, fontSize: "0.72rem" }}
+                    />
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="caption" sx={{ color: "text.secondary" }}>
+                      {user.lastLoginAt
+                        ? new Date(user.lastLoginAt).toLocaleString()
+                        : "—"}
+                    </Typography>
+                  </TableCell>
+                  <TableCell>
+                    <Box sx={{ display: "flex", gap: 0.5 }}>
+                      <Tooltip title="View">
+                        <IconButton size="small" onClick={() => onView(user)}>
+                          <Visibility fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
+                      <Tooltip title="Edit">
+                        <IconButton size="small" onClick={() => onEdit(user)}>
+                          <Edit fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
+                      <Tooltip title={user.isActive ? "Deactivate" : "Activate"}>
+                        <IconButton
+                          size="small"
+                          color={user.isActive ? "warning" : "success"}
+                          onClick={() => onToggleActive(user)}
+                          disabled={isSelf}
+                        >
+                          {user.isActive ? (
+                            <ToggleOff fontSize="small" />
+                          ) : (
+                            <ToggleOn fontSize="small" />
+                          )}
+                        </IconButton>
+                      </Tooltip>
+                      <Tooltip title="Delete">
+                        <span>
+                          <IconButton
+                            size="small"
+                            color="error"
+                            onClick={() => onDelete(user)}
+                            disabled={isSelf}
+                          >
+                            <Delete fontSize="small" />
+                          </IconButton>
+                        </span>
+                      </Tooltip>
+                    </Box>
+                  </TableCell>
+                </TableRow>
+              );
+            })
+          )}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,0 +1,59 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  type ReactNode,
+} from "react";
+import type { User } from "../types";
+import * as AuthService from "../services/AuthService";
+import type { LoginResult } from "../services/AuthService";
+
+interface AuthContextValue {
+  currentUser: User | null;
+  login: (email: string, password: string) => LoginResult;
+  logout: () => void;
+  isAuthenticated: boolean;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [currentUser, setCurrentUser] = useState<User | null>(null);
+  const [initialized, setInitialized] = useState(false);
+
+  useEffect(() => {
+    const stored = AuthService.getStoredSession();
+    setCurrentUser(stored);
+    setInitialized(true);
+  }, []);
+
+  const login = (email: string, password: string): LoginResult => {
+    const result = AuthService.login(email, password);
+    if (result.success && result.user) {
+      setCurrentUser(result.user);
+    }
+    return result;
+  };
+
+  const logout = () => {
+    AuthService.logout();
+    setCurrentUser(null);
+  };
+
+  if (!initialized) return null;
+
+  return (
+    <AuthContext.Provider
+      value={{ currentUser, login, logout, isAuthenticated: currentUser !== null }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth must be used within AuthProvider");
+  return ctx;
+}

--- a/src/data/users.json
+++ b/src/data/users.json
@@ -34,5 +34,14 @@
     "lastName": "Prevarin",
     "role": "SUPPORT",
     "isActive": true
+  },
+    {
+    "id": "USR-005",
+    "email": "support@urbanova.com",
+    "password": "support",
+    "firstName": "Ludovico",
+    "lastName": "Cammarata",
+    "role": "SUPPORT",
+    "isActive": true
   }
 ]

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,15 @@
 import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
+import "leaflet/dist/leaflet.css";
 
 import { initializeServices } from "./bootstrap/initializeServices";
 import { router } from "./router";
-
-initializeServices();
+import { AuthProvider } from "./contexts/AuthContext";
 
 initializeServices();
 
 createRoot(document.getElementById("root")!).render(
-  <RouterProvider router={router} />,
+  <AuthProvider>
+    <RouterProvider router={router} />
+  </AuthProvider>,
 );

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,272 @@
+import { useState, useEffect } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
+import {
+  Box,
+  Card,
+  CardContent,
+  TextField,
+  Button,
+  Typography,
+  Alert,
+  IconButton,
+  InputAdornment,
+  Link,
+  Divider,
+  Chip,
+  CircularProgress,
+} from "@mui/material";
+import {
+  Visibility,
+  VisibilityOff,
+  DirectionsBus,
+} from "@mui/icons-material";
+import { useAuth } from "../contexts/AuthContext";
+import { getLockoutUntil } from "../services/AuthService";
+
+function formatCountdown(lockUntil: number): string {
+  const ms = lockUntil - Date.now();
+  if (ms <= 0) return "0s";
+  const totalSec = Math.ceil(ms / 1000);
+  const m = Math.floor(totalSec / 60);
+  const s = totalSec % 60;
+  return m > 0 ? `${m}m ${s}s` : `${s}s`;
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export default function Login() {
+  const { login, isAuthenticated } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const from = (location.state as { from?: { pathname: string } })?.from?.pathname ?? "/";
+
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<{ email?: string; password?: string }>({});
+  const [countdown, setCountdown] = useState<string | null>(null);
+  const [lockUntil, setLockUntil] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (isAuthenticated) navigate(from, { replace: true });
+  }, [isAuthenticated, navigate, from]);
+
+  useEffect(() => {
+    if (!lockUntil) return;
+    const tick = setInterval(() => {
+      if (Date.now() >= lockUntil) {
+        setLockUntil(null);
+        setCountdown(null);
+        setError(null);
+        clearInterval(tick);
+      } else {
+        setCountdown(formatCountdown(lockUntil));
+      }
+    }, 1000);
+    setCountdown(formatCountdown(lockUntil));
+    return () => clearInterval(tick);
+  }, [lockUntil]);
+
+  function validate(): boolean {
+    const errs: { email?: string; password?: string } = {};
+    if (!email.trim()) errs.email = "This field is required";
+    else if (!EMAIL_RE.test(email)) errs.email = "Please enter a valid email address";
+    if (!password) errs.password = "This field is required";
+    setFieldErrors(errs);
+    return Object.keys(errs).length === 0;
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!validate()) return;
+
+    const existing = getLockoutUntil(email);
+    if (existing) {
+      setLockUntil(existing);
+      setError(`Too many attempts. Try again in ${formatCountdown(existing)}.`);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    await new Promise((r) => setTimeout(r, 600));
+
+    const result = login(email, password);
+    setLoading(false);
+
+    if (result.success) {
+      navigate(from, { replace: true });
+      return;
+    }
+
+    if (result.error === "ACCOUNT_LOCKED") {
+      setLockUntil(result.lockUntil ?? null);
+      setError(
+        `Too many attempts. Try again in ${result.lockUntil ? formatCountdown(result.lockUntil) : "a few minutes"}.`,
+      );
+    } else if (result.error === "ACCOUNT_INACTIVE") {
+      setError("Your account is inactive. Contact your administrator.");
+    } else {
+      setError("Invalid email or password.");
+    }
+  }
+
+  const isLocked = lockUntil !== null && Date.now() < lockUntil;
+
+  return (
+    <Box
+      sx={{
+        minHeight: "100vh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "linear-gradient(135deg, #1565c0 0%, #42a5f5 100%)",
+        p: 2,
+      }}
+    >
+      <Card elevation={8} sx={{ width: "100%", maxWidth: 420, borderRadius: 3 }}>
+        <CardContent sx={{ p: 4 }}>
+          {/* Logo / Brand */}
+          <Box sx={{ textAlign: "center", mb: 3 }}>
+            <Box
+              sx={{
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                width: 56,
+                height: 56,
+                borderRadius: "50%",
+                bgcolor: "primary.main",
+                mb: 1.5,
+              }}
+            >
+              <DirectionsBus sx={{ color: "white", fontSize: 30 }} />
+            </Box>
+            <Typography variant="h5" sx={{ fontWeight: 700, letterSpacing: -0.5 }}>
+              UrbaNova
+            </Typography>
+            <Typography variant="body2" sx={{ color: "text.secondary", mt: 0.5 }}>
+              Fleet Management System
+            </Typography>
+          </Box>
+
+          {/* Error alert */}
+          {error && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {isLocked && countdown ? `Too many attempts. Try again in ${countdown}.` : error}
+            </Alert>
+          )}
+
+          <Box component="form" onSubmit={handleSubmit} noValidate>
+            <TextField
+              label="Email"
+              type="email"
+              fullWidth
+              value={email}
+              onChange={(e) => {
+                setEmail(e.target.value);
+                setFieldErrors((prev) => ({ ...prev, email: undefined }));
+              }}
+              error={!!fieldErrors.email}
+              helperText={fieldErrors.email}
+              disabled={loading || isLocked}
+              autoComplete="email"
+              autoFocus
+              sx={{ mb: 2 }}
+            />
+            <TextField
+              label="Password"
+              type={showPassword ? "text" : "password"}
+              fullWidth
+              value={password}
+              onChange={(e) => {
+                setPassword(e.target.value);
+                setFieldErrors((prev) => ({ ...prev, password: undefined }));
+              }}
+              error={!!fieldErrors.password}
+              helperText={fieldErrors.password}
+              disabled={loading || isLocked}
+              autoComplete="current-password"
+              slotProps={{
+                input: {
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      <IconButton
+                        onClick={() => setShowPassword((v) => !v)}
+                        edge="end"
+                        tabIndex={-1}
+                        disabled={loading || isLocked}
+                      >
+                        {showPassword ? <VisibilityOff /> : <Visibility />}
+                      </IconButton>
+                    </InputAdornment>
+                  ),
+                },
+              }}
+              sx={{ mb: 1 }}
+            />
+
+            <Box sx={{ textAlign: "right", mb: 2.5 }}>
+              <Link
+                href="#"
+                variant="body2"
+                onClick={(e) => e.preventDefault()}
+                sx={{ color: "primary.main" }}
+              >
+                Forgot password?
+              </Link>
+            </Box>
+
+            <Button
+              type="submit"
+              variant="contained"
+              fullWidth
+              size="large"
+              disabled={loading || isLocked}
+              sx={{ borderRadius: 2, py: 1.25, fontWeight: 600 }}
+            >
+              {loading ? (
+                <CircularProgress size={22} sx={{ color: "inherit" }} />
+              ) : (
+                "Sign In"
+              )}
+            </Button>
+          </Box>
+
+          <Divider sx={{ my: 3 }}>
+            <Typography variant="caption" sx={{ color: "text.secondary" }}>
+              Demo credentials
+            </Typography>
+          </Divider>
+
+          <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", justifyContent: "center" }}>
+            {[
+              { label: "Admin", email: "admin@urbanova.com", pw: "admin" },
+              { label: "Technician", email: "tech@urbanova.com", pw: "tech" },
+              { label: "Support", email: "support@urbanova.com", pw: "support" },
+              { label: "User", email: "user@urbanova.com", pw: "user" },
+            ].map(({ label, email: e, pw }) => (
+              <Chip
+                key={label}
+                label={label}
+                size="small"
+                clickable
+                disabled={loading || isLocked}
+                onClick={() => {
+                  setEmail(e);
+                  setPassword(pw);
+                  setFieldErrors({});
+                  setError(null);
+                }}
+                sx={{ fontSize: "0.75rem" }}
+              />
+            ))}
+          </Box>
+        </CardContent>
+      </Card>
+    </Box>
+  );
+}

--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -1,12 +1,583 @@
-import { Box, Typography } from "@mui/material";
+import { useState, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  Container,
+  Box,
+  Typography,
+  Button,
+  Stack,
+  Paper,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  MenuItem,
+  FormControlLabel,
+  Switch,
+  Alert,
+  Divider,
+  Chip,
+  IconButton,
+  InputAdornment,
+} from "@mui/material";
+import {
+  Add,
+  Visibility,
+  VisibilityOff,
+  LockOutlined,
+} from "@mui/icons-material";
+import { useAuth } from "../contexts/AuthContext";
+import {
+  getAllUsers,
+  addUser,
+  updateUser,
+  deleteUser,
+  updateUserStatus,
+} from "../services/UserService";
+import type { User, UserRole, PassType } from "../types";
+import SearchInput from "../components/atoms/SearchInput";
+import UsersTable from "../components/organisms/UsersTable";
+import RoleBadge from "../components/atoms/RoleBadge";
+
+const ALLOWED_ROLES: UserRole[] = ["ADMIN", "TECHNICIAN"];
+const ALL_ROLES: UserRole[] = ["ADMIN", "OPERATOR", "TECHNICIAN", "SUPPORT", "USER"];
+const ALL_PASS_TYPES: PassType[] = ["NONE", "DAILY", "WEEKLY", "MONTHLY", "YEARLY"];
+
+interface FormState {
+  firstName: string;
+  lastName: string;
+  email: string;
+  password: string;
+  role: UserRole;
+  isActive: boolean;
+  passType: PassType;
+  passExpiryDate: string;
+  balance: number;
+}
+
+const EMPTY_FORM: FormState = {
+  firstName: "",
+  lastName: "",
+  email: "",
+  password: "",
+  role: "USER",
+  isActive: true,
+  passType: "NONE",
+  passExpiryDate: "",
+  balance: 0,
+};
+
+function userToForm(user: User): FormState {
+  return {
+    firstName: user.firstName,
+    lastName: user.lastName,
+    email: user.email,
+    password: user.password,
+    role: user.role,
+    isActive: user.isActive,
+    passType: (user.passType as PassType) ?? "NONE",
+    passExpiryDate: user.passExpiryDate ?? "",
+    balance: user.balance ?? 0,
+  };
+}
+
+function AccessDenied() {
+  const navigate = useNavigate();
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        minHeight: "50vh",
+        gap: 2,
+      }}
+    >
+      <LockOutlined sx={{ fontSize: 64, color: "text.disabled" }} />
+      <Typography variant="h5" sx={{ fontWeight: 700 }}>
+        Access Restricted
+      </Typography>
+      <Typography variant="body2" sx={{ color: "text.secondary" }}>
+        Only Admins and Technicians can manage users.
+      </Typography>
+      <Button variant="outlined" onClick={() => navigate("/")}>
+        Back to Home
+      </Button>
+    </Box>
+  );
+}
 
 export default function Users() {
+  const { currentUser } = useAuth();
+
+  if (!currentUser || !ALLOWED_ROLES.includes(currentUser.role as UserRole)) {
+    return <AccessDenied />;
+  }
+
+  return <UsersPage currentUser={currentUser} />;
+}
+
+function UsersPage({ currentUser }: { currentUser: User }) {
+  const [users, setUsers] = useState<User[]>(() => getAllUsers());
+  const [search, setSearch] = useState("");
+  const [roleFilter, setRoleFilter] = useState<UserRole | "">("");
+  const [statusFilter, setStatusFilter] = useState<"" | "active" | "inactive">("");
+  const [sortBy, setSortBy] = useState("firstName");
+  const [sortOrder, setSortOrder] = useState<"asc" | "desc">("asc");
+
+  const [formOpen, setFormOpen] = useState(false);
+  const [formMode, setFormMode] = useState<"add" | "edit">("add");
+  const [editingUser, setEditingUser] = useState<User | null>(null);
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [formErrors, setFormErrors] = useState<Partial<Record<keyof FormState, string>>>({});
+  const [showPassword, setShowPassword] = useState(false);
+
+  const [viewUser, setViewUser] = useState<User | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<User | null>(null);
+
+  const [error, setError] = useState<string | null>(null);
+
+  function reload() {
+    setUsers(getAllUsers());
+  }
+
+  const filtered = useMemo(() => {
+    let result = [...users];
+
+    if (search) {
+      const q = search.toLowerCase();
+      result = result.filter(
+        (u) =>
+          u.id.toLowerCase().includes(q) ||
+          u.firstName.toLowerCase().includes(q) ||
+          u.lastName.toLowerCase().includes(q) ||
+          u.email.toLowerCase().includes(q) ||
+          u.role.toLowerCase().includes(q),
+      );
+    }
+
+    if (roleFilter) result = result.filter((u) => u.role === roleFilter);
+    if (statusFilter === "active") result = result.filter((u) => u.isActive);
+    if (statusFilter === "inactive") result = result.filter((u) => !u.isActive);
+
+    result.sort((a, b) => {
+      const aVal = String(a[sortBy as keyof User] ?? "").toLowerCase();
+      const bVal = String(b[sortBy as keyof User] ?? "").toLowerCase();
+      const cmp = aVal < bVal ? -1 : aVal > bVal ? 1 : 0;
+      return sortOrder === "asc" ? cmp : -cmp;
+    });
+
+    return result;
+  }, [users, search, roleFilter, statusFilter, sortBy, sortOrder]);
+
+  function handleSort(field: string) {
+    if (sortBy === field) setSortOrder((o) => (o === "asc" ? "desc" : "asc"));
+    else { setSortBy(field); setSortOrder("asc"); }
+  }
+
+  function openAdd() {
+    setForm(EMPTY_FORM);
+    setFormErrors({});
+    setShowPassword(false);
+    setFormMode("add");
+    setEditingUser(null);
+    setFormOpen(true);
+  }
+
+  function openEdit(user: User) {
+    setForm(userToForm(user));
+    setFormErrors({});
+    setShowPassword(false);
+    setFormMode("edit");
+    setEditingUser(user);
+    setFormOpen(true);
+  }
+
+  function validateForm(): boolean {
+    const errs: Partial<Record<keyof FormState, string>> = {};
+    if (!form.firstName.trim()) errs.firstName = "Required";
+    if (!form.lastName.trim()) errs.lastName = "Required";
+    if (!form.email.trim()) errs.email = "Required";
+    else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email))
+      errs.email = "Invalid email";
+    if (formMode === "add" && !form.password) errs.password = "Required";
+    if (form.passType !== "NONE" && !form.passExpiryDate)
+      errs.passExpiryDate = "Required for this pass type";
+    setFormErrors(errs);
+    return Object.keys(errs).length === 0;
+  }
+
+  function handleSave() {
+    if (!validateForm()) return;
+    setError(null);
+
+    try {
+      if (formMode === "add") {
+        const newUser: User = {
+          id: `USR-${Date.now()}`,
+          firstName: form.firstName.trim(),
+          lastName: form.lastName.trim(),
+          email: form.email.trim(),
+          password: form.password,
+          role: form.role,
+          isActive: form.isActive,
+          passType: form.passType !== "NONE" ? form.passType : "NONE",
+          passExpiryDate: form.passType !== "NONE" ? form.passExpiryDate : undefined,
+          balance: form.balance,
+        };
+        addUser(newUser);
+      } else if (editingUser) {
+        const updates: Partial<User> = {
+          firstName: form.firstName.trim(),
+          lastName: form.lastName.trim(),
+          email: form.email.trim(),
+          role: form.role,
+          isActive: form.isActive,
+          passType: form.passType,
+          passExpiryDate: form.passType !== "NONE" ? form.passExpiryDate : undefined,
+          balance: form.balance,
+        };
+        if (form.password) updates.password = form.password;
+        updateUser(editingUser.id, updates);
+      }
+      reload();
+      setFormOpen(false);
+    } catch {
+      setError("Failed to save user. Please try again.");
+    }
+  }
+
+  function handleToggleActive(user: User) {
+    updateUserStatus(user.id, user.isActive ? "INACTIVE" : "ACTIVE");
+    reload();
+  }
+
+  function confirmDelete() {
+    if (!deleteTarget) return;
+    deleteUser(deleteTarget.id);
+    reload();
+    setDeleteTarget(null);
+  }
+
+  const f = form;
+  const setF = (patch: Partial<FormState>) => setForm((prev) => ({ ...prev, ...patch }));
+
   return (
-    <Box>
-      <Typography variant="h4" gutterBottom>
-        Users
-      </Typography>
-      <Typography variant="body1">Manage your users here.</Typography>
-    </Box>
+    <Container maxWidth="lg" sx={{ py: 4 }}>
+      <Stack spacing={3}>
+        {/* Header */}
+        <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
+          <Box>
+            <Typography variant="h4" sx={{ fontWeight: "bold" }}>
+              User Management
+            </Typography>
+            <Typography variant="body2" sx={{ color: "text.secondary", mt: 0.5 }}>
+              {users.length} users registered
+            </Typography>
+          </Box>
+          <Button variant="contained" startIcon={<Add />} onClick={openAdd}>
+            Add User
+          </Button>
+        </Box>
+
+        {error && (
+          <Alert severity="error" onClose={() => setError(null)}>
+            {error}
+          </Alert>
+        )}
+
+        {/* Search + Filters */}
+        <Paper variant="outlined" sx={{ p: 2, borderRadius: 2 }}>
+          <Stack spacing={1.5}>
+            <SearchInput
+              value={search}
+              onChange={setSearch}
+              placeholder="Search by name, email, ID, or role"
+            />
+            <Stack direction="row" spacing={2} sx={{ flexWrap: "wrap" }}>
+              <TextField
+                select
+                label="Role"
+                size="small"
+                value={roleFilter}
+                onChange={(e) => setRoleFilter(e.target.value as UserRole | "")}
+                sx={{ minWidth: 140 }}
+              >
+                <MenuItem value="">All roles</MenuItem>
+                {ALL_ROLES.map((r) => (
+                  <MenuItem key={r} value={r}>{r}</MenuItem>
+                ))}
+              </TextField>
+              <TextField
+                select
+                label="Status"
+                size="small"
+                value={statusFilter}
+                onChange={(e) => setStatusFilter(e.target.value as "" | "active" | "inactive")}
+                sx={{ minWidth: 130 }}
+              >
+                <MenuItem value="">All</MenuItem>
+                <MenuItem value="active">Active</MenuItem>
+                <MenuItem value="inactive">Inactive</MenuItem>
+              </TextField>
+              <Typography
+                variant="caption"
+                sx={{ color: "text.secondary", alignSelf: "center", ml: "auto" }}
+              >
+                Showing {filtered.length} of {users.length}
+              </Typography>
+            </Stack>
+          </Stack>
+        </Paper>
+
+        {/* Table */}
+        <UsersTable
+          users={filtered}
+          sortBy={sortBy}
+          sortOrder={sortOrder}
+          onSort={handleSort}
+          onView={setViewUser}
+          onEdit={openEdit}
+          onToggleActive={handleToggleActive}
+          onDelete={setDeleteTarget}
+          currentUserId={currentUser.id}
+        />
+      </Stack>
+
+      {/* ── Add / Edit Form Dialog ── */}
+      <Dialog open={formOpen} onClose={() => setFormOpen(false)} maxWidth="sm" fullWidth>
+        <DialogTitle sx={{ fontWeight: 700 }}>
+          {formMode === "add" ? "Add User" : "Edit User"}
+        </DialogTitle>
+        <DialogContent dividers>
+          <Stack spacing={2} sx={{ pt: 0.5 }}>
+            <Stack direction="row" spacing={2}>
+              <TextField
+                label="First Name"
+                fullWidth
+                size="small"
+                value={f.firstName}
+                onChange={(e) => setF({ firstName: e.target.value })}
+                error={!!formErrors.firstName}
+                helperText={formErrors.firstName}
+              />
+              <TextField
+                label="Last Name"
+                fullWidth
+                size="small"
+                value={f.lastName}
+                onChange={(e) => setF({ lastName: e.target.value })}
+                error={!!formErrors.lastName}
+                helperText={formErrors.lastName}
+              />
+            </Stack>
+            <TextField
+              label="Email"
+              type="email"
+              fullWidth
+              size="small"
+              value={f.email}
+              onChange={(e) => setF({ email: e.target.value })}
+              error={!!formErrors.email}
+              helperText={formErrors.email}
+            />
+            <TextField
+              label={formMode === "edit" ? "New Password (leave blank to keep)" : "Password"}
+              type={showPassword ? "text" : "password"}
+              fullWidth
+              size="small"
+              value={f.password}
+              onChange={(e) => setF({ password: e.target.value })}
+              error={!!formErrors.password}
+              helperText={formErrors.password}
+              slotProps={{
+                input: {
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      <IconButton size="small" onClick={() => setShowPassword((v) => !v)} edge="end">
+                        {showPassword ? <VisibilityOff fontSize="small" /> : <Visibility fontSize="small" />}
+                      </IconButton>
+                    </InputAdornment>
+                  ),
+                },
+              }}
+            />
+            <Stack direction="row" spacing={2}>
+              <TextField
+                select
+                label="Role"
+                fullWidth
+                size="small"
+                value={f.role}
+                onChange={(e) => setF({ role: e.target.value as UserRole })}
+              >
+                {ALL_ROLES.map((r) => (
+                  <MenuItem key={r} value={r}>{r}</MenuItem>
+                ))}
+              </TextField>
+              <TextField
+                label="Balance (€)"
+                type="number"
+                fullWidth
+                size="small"
+                value={f.balance}
+                onChange={(e) => setF({ balance: parseFloat(e.target.value) || 0 })}
+              />
+            </Stack>
+            <Divider />
+            <Stack direction="row" spacing={2}>
+              <TextField
+                select
+                label="Pass Type"
+                fullWidth
+                size="small"
+                value={f.passType}
+                onChange={(e) => setF({ passType: e.target.value as PassType })}
+              >
+                {ALL_PASS_TYPES.map((p) => (
+                  <MenuItem key={p} value={p}>{p}</MenuItem>
+                ))}
+              </TextField>
+              {f.passType !== "NONE" && (
+                <TextField
+                  label="Pass Expiry"
+                  type="date"
+                  fullWidth
+                  size="small"
+                  value={f.passExpiryDate}
+                  onChange={(e) => setF({ passExpiryDate: e.target.value })}
+                  error={!!formErrors.passExpiryDate}
+                  helperText={formErrors.passExpiryDate}
+                  slotProps={{ inputLabel: { shrink: true } }}
+                />
+              )}
+            </Stack>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={f.isActive}
+                  onChange={(e) => setF({ isActive: e.target.checked })}
+                  size="small"
+                />
+              }
+              label={
+                <Typography variant="body2">
+                  Account active
+                </Typography>
+              }
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, py: 2 }}>
+          <Button onClick={() => setFormOpen(false)}>Cancel</Button>
+          <Button variant="contained" onClick={handleSave}>
+            {formMode === "add" ? "Create" : "Save"}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* ── View Detail Dialog ── */}
+      <Dialog open={!!viewUser} onClose={() => setViewUser(null)} maxWidth="xs" fullWidth>
+        {viewUser && (
+          <>
+            <DialogTitle sx={{ fontWeight: 700 }}>
+              {viewUser.firstName} {viewUser.lastName}
+            </DialogTitle>
+            <DialogContent dividers>
+              <Stack spacing={1.5}>
+                <Stack direction="row" sx={{ justifyContent: "space-between" }}>
+                  <Typography variant="body2" sx={{ color: "text.secondary" }}>ID</Typography>
+                  <Typography variant="body2" sx={{ fontFamily: "monospace", fontWeight: 600 }}>
+                    {viewUser.id}
+                  </Typography>
+                </Stack>
+                <Stack direction="row" sx={{ justifyContent: "space-between" }}>
+                  <Typography variant="body2" sx={{ color: "text.secondary" }}>Email</Typography>
+                  <Typography variant="body2">{viewUser.email}</Typography>
+                </Stack>
+                <Stack direction="row" sx={{ justifyContent: "space-between", alignItems: "center" }}>
+                  <Typography variant="body2" sx={{ color: "text.secondary" }}>Role</Typography>
+                  <RoleBadge role={viewUser.role} />
+                </Stack>
+                <Stack direction="row" sx={{ justifyContent: "space-between", alignItems: "center" }}>
+                  <Typography variant="body2" sx={{ color: "text.secondary" }}>Status</Typography>
+                  <Chip
+                    size="small"
+                    label={viewUser.isActive ? "Active" : "Inactive"}
+                    color={viewUser.isActive ? "success" : "default"}
+                    sx={{ fontWeight: 600 }}
+                  />
+                </Stack>
+                {viewUser.passType && viewUser.passType !== "NONE" && (
+                  <>
+                    <Stack direction="row" sx={{ justifyContent: "space-between" }}>
+                      <Typography variant="body2" sx={{ color: "text.secondary" }}>Pass</Typography>
+                      <Typography variant="body2">{viewUser.passType}</Typography>
+                    </Stack>
+                    {viewUser.passExpiryDate && (
+                      <Stack direction="row" sx={{ justifyContent: "space-between" }}>
+                        <Typography variant="body2" sx={{ color: "text.secondary" }}>Expires</Typography>
+                        <Typography variant="body2">
+                          {new Date(viewUser.passExpiryDate).toLocaleDateString()}
+                        </Typography>
+                      </Stack>
+                    )}
+                  </>
+                )}
+                {viewUser.balance !== undefined && (
+                  <Stack direction="row" sx={{ justifyContent: "space-between" }}>
+                    <Typography variant="body2" sx={{ color: "text.secondary" }}>Balance</Typography>
+                    <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                      €{viewUser.balance.toFixed(2)}
+                    </Typography>
+                  </Stack>
+                )}
+                <Stack direction="row" sx={{ justifyContent: "space-between" }}>
+                  <Typography variant="body2" sx={{ color: "text.secondary" }}>Last login</Typography>
+                  <Typography variant="body2">
+                    {viewUser.lastLoginAt
+                      ? new Date(viewUser.lastLoginAt).toLocaleString()
+                      : "Never"}
+                  </Typography>
+                </Stack>
+              </Stack>
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={() => setViewUser(null)}>Close</Button>
+              <Button
+                variant="outlined"
+                onClick={() => { setViewUser(null); openEdit(viewUser); }}
+              >
+                Edit
+              </Button>
+            </DialogActions>
+          </>
+        )}
+      </Dialog>
+
+      {/* ── Delete Confirm Dialog ── */}
+      <Dialog open={!!deleteTarget} onClose={() => setDeleteTarget(null)} maxWidth="xs" fullWidth>
+        {deleteTarget && (
+          <>
+            <DialogTitle sx={{ fontWeight: 700 }}>Delete User</DialogTitle>
+            <DialogContent>
+              <Typography variant="body2">
+                Permanently delete{" "}
+                <strong>{deleteTarget.firstName} {deleteTarget.lastName}</strong>{" "}
+                ({deleteTarget.email})? This cannot be undone.
+              </Typography>
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={() => setDeleteTarget(null)}>Cancel</Button>
+              <Button variant="contained" color="error" onClick={confirmDelete}>
+                Delete
+              </Button>
+            </DialogActions>
+          </>
+        )}
+      </Dialog>
+    </Container>
   );
 }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,17 +1,31 @@
 import { createBrowserRouter } from "react-router-dom";
-import React from "react";
+import React, { lazy } from "react";
 
 import { routes, notFoundRoute } from "./routes";
 import Layout from "../components/Layout";
+import RequireAuth from "../components/RequireAuth";
 
-// Find the index route
+const Login = lazy(() => import("../pages/Login"));
+
 const indexRoute = routes.find((r) => r.isIndex);
 const childRoutes = routes.filter((r) => !r.isIndex);
 
 export const router = createBrowserRouter([
   {
+    path: "/login",
+    element: React.createElement(
+      React.Suspense,
+      { fallback: null },
+      React.createElement(Login),
+    ),
+  },
+  {
     path: "/",
-    element: React.createElement(Layout),
+    element: React.createElement(
+      RequireAuth,
+      null,
+      React.createElement(Layout),
+    ),
     children: [
       ...childRoutes.map((route) => ({
         path: route.path,

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -27,6 +27,7 @@ export interface RouteConfig {
   name: string;
   icon?: ComponentType;
   isIndex?: boolean;
+  allowedRoles?: string[];
 }
 
 export const routes: RouteConfig[] = [
@@ -45,26 +46,31 @@ export const routes: RouteConfig[] = [
     path: "/trips",
     component: Trips,
     name: "Trips",
+    allowedRoles: ["ADMIN", "TECHNICIAN", "SUPPORT"],
   },
   {
     path: "/vehicles",
     component: Vehicles,
     name: "Vehicles",
+    allowedRoles: ["ADMIN", "TECHNICIAN", "SUPPORT"],
   },
   {
     path: "/users",
     component: Users,
     name: "Users",
+    allowedRoles: ["ADMIN", "TECHNICIAN"],
   },
   {
     path: "/tickets",
     component: Tickets,
     name: "Tickets",
+    allowedRoles: ["ADMIN", "SUPPORT"],
   },
   {
     path: "/analytics",
     component: Analytics,
     name: "Analytics",
+    allowedRoles: ["ADMIN"],
   },
   {
     path: "/settings",

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -1,0 +1,114 @@
+import { getUserByEmail, getUserById, recordLogin } from "./UserService";
+import type { User } from "../types";
+
+const SESSION_KEY = "urbanova_auth_session";
+const ATTEMPTS_PREFIX = "urbanova_auth_attempts_";
+const MAX_ATTEMPTS = 5;
+const LOCKOUT_MS = 5 * 60 * 1000;
+
+interface Session {
+  userId: string;
+  loginAt: string;
+}
+
+interface AttemptRecord {
+  count: number;
+  lockUntil: number | null;
+}
+
+export type LoginError =
+  | "INVALID_CREDENTIALS"
+  | "ACCOUNT_LOCKED"
+  | "ACCOUNT_INACTIVE";
+
+export interface LoginResult {
+  success: boolean;
+  user?: User;
+  error?: LoginError;
+  lockUntil?: number;
+}
+
+function attemptKey(email: string): string {
+  return `${ATTEMPTS_PREFIX}${email.toLowerCase()}`;
+}
+
+function getRecord(email: string): AttemptRecord {
+  try {
+    const raw = localStorage.getItem(attemptKey(email));
+    if (raw) return JSON.parse(raw);
+  } catch {}
+  return { count: 0, lockUntil: null };
+}
+
+function saveRecord(email: string, record: AttemptRecord): void {
+  localStorage.setItem(attemptKey(email), JSON.stringify(record));
+}
+
+function recordFailedAttempt(email: string): number | null {
+  const record = getRecord(email);
+  const count = record.count + 1;
+  const lockUntil = count >= MAX_ATTEMPTS ? Date.now() + LOCKOUT_MS : null;
+  saveRecord(email, { count, lockUntil });
+  return lockUntil;
+}
+
+function clearAttempts(email: string): void {
+  localStorage.removeItem(attemptKey(email));
+}
+
+export function getLockoutUntil(email: string): number | null {
+  const record = getRecord(email);
+  if (record.lockUntil && record.lockUntil <= Date.now()) {
+    clearAttempts(email);
+    return null;
+  }
+  return record.lockUntil;
+}
+
+export function getRemainingAttempts(email: string): number {
+  return Math.max(0, MAX_ATTEMPTS - getRecord(email).count);
+}
+
+export function login(email: string, password: string): LoginResult {
+  const lockUntil = getLockoutUntil(email);
+  if (lockUntil) {
+    return { success: false, error: "ACCOUNT_LOCKED", lockUntil };
+  }
+
+  const user = getUserByEmail(email);
+  if (!user || user.password !== password) {
+    const newLock = recordFailedAttempt(email);
+    if (newLock) {
+      return { success: false, error: "ACCOUNT_LOCKED", lockUntil: newLock };
+    }
+    return { success: false, error: "INVALID_CREDENTIALS" };
+  }
+
+  if (!user.isActive) {
+    return { success: false, error: "ACCOUNT_INACTIVE" };
+  }
+
+  clearAttempts(email);
+  recordLogin(user.id);
+
+  const session: Session = { userId: user.id, loginAt: new Date().toISOString() };
+  localStorage.setItem(SESSION_KEY, JSON.stringify(session));
+
+  return { success: true, user };
+}
+
+export function logout(): void {
+  localStorage.removeItem(SESSION_KEY);
+}
+
+export function getStoredSession(): User | null {
+  try {
+    const raw = localStorage.getItem(SESSION_KEY);
+    if (!raw) return null;
+    const session: Session = JSON.parse(raw);
+    const user = getUserById(session.userId);
+    return user?.isActive ? user : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
- Frontend-only auth with mock credentials matched against in-memory user store; session persisted to localStorage (userId only)
- Rate limiting: 5 failed attempts triggers 5-minute lockout with live countdown; tracked per email in localStorage
- RequireAuth guard redirects unauthenticated users to /login, preserving the intended destination for post-login redirect
- Role-based sidebar: routes declare allowedRoles, Layout filters nav items per current user; page-level guard for direct navigation
- Users page (/users) built with full CRUD: table, add/edit dialog, toggle active, delete confirm; restricted to ADMIN + TECHNICIAN
- Access matrix: USER sees Home/Stations/Settings; SUPPORT adds Trips/Vehicles/Tickets; TECHNICIAN adds Users; ADMIN sees all